### PR TITLE
Add OMS-Auditd-Plugin submodule under auoms dir

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,7 @@
 	path = dsc
 	url = git@github.com:Microsoft/PowerShell-DSC-for-Linux.git
 	branch = master
+[submodule "auoms"]
+	path = auoms
+	url = git@github.com:Microsoft/OMS-Auditd-Plugin.git
+	branch = master

--- a/auoms.version
+++ b/auoms.version
@@ -1,0 +1,13 @@
+# -*- mode: Makefile; -*-
+#--------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+#--------------------------------------------------------------------------------
+# 2016-11-10
+#--------------------------------------------------------------------------------
+
+AUOMS_BUILDVERSION_MAJOR=0
+AUOMS_BUILDVERSION_MINOR=1
+AUOMS_BUILDVERSION_PATCH=0
+AUOMS_BUILDVERSION_BUILDNR=1
+AUOMS_BUILDVERSION_DATE=20161110
+AUOMS_BUILDVERSION_STATUS=Developer_Build


### PR DESCRIPTION
See also corresponding pull-requests for OMS-Agent-for-Linux and PowerShell-DSC-for-Linux as well as code committed to master branch of OMS-Auditd-Plugin (LCA approved, but not yet public)