### PR TITLE
Update pipelines to successfully download artifacts

### DIFF
--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -40,7 +40,6 @@ versioning:
       command: 'pipeline-version.cmd'
 
 workspace_options:
-  download_current_artifacts: true
   force_workspace_wipe: false
   enable_legacy_networking: true
 

--- a/pipeline-dsc-signing.cmd
+++ b/pipeline-dsc-signing.cmd
@@ -3,18 +3,13 @@ set SIGNING_DIR=pipeline-signing
 cd /d %DIR%
 
 dir .
+dir %DIR%drop
 
-dir %CDP_TEMP_PRIOR_DROP_FOLDER_CONTAINER_PATH%\current\drop
+mkdir %DIR%%SIGNING_DIR%
 
-mkdir %DIR%\%SIGNING_DIR%
+Xcopy /E /I /Y %DIR%drop\Build_x64\outputs\build\buildoutput\Linux_ULINUX_1.0_x64_64_Release\dsc %DIR%%SIGNING_DIR%\dsc
 
-dir %CDP_TEMP_PRIOR_DROP_FOLDER_CONTAINER_PATH%\current\drop
-dir %CDP_TEMP_PRIOR_DROP_FOLDER_CONTAINER_PATH%\current\drop\Build_x64\outputs\build\buildoutput\Linux_ULINUX_1.0_x64_64_Release
-dir %CDP_TEMP_PRIOR_DROP_FOLDER_CONTAINER_PATH%\current\drop\Build_x64\outputs\build\buildoutput\Linux_ULINUX_1.0_x64_64_Release\dsc
-
-Xcopy /E /I /Y %CDP_TEMP_PRIOR_DROP_FOLDER_CONTAINER_PATH%\current\drop\Build_x64\outputs\build\buildoutput\Linux_ULINUX_1.0_x64_64_Release\dsc %DIR%\%SIGNING_DIR%\dsc
-
-mkdir "%DIR%\%SIGNING_DIR%\dsc\signing"
+mkdir "%DIR%%SIGNING_DIR%\dsc\signing"
 
 powershell -NoProfile -ExecutionPolicy Unrestricted -Command "& '%~dp0pipeline-dsc-signing.ps1'"
 

--- a/pipeline-oms-signing.cmd
+++ b/pipeline-oms-signing.cmd
@@ -3,18 +3,15 @@ set SIGNING_DIR=pipeline-signing
 cd /d %DIR%
 
 dir .
+dir %DIR%drop
 
-dir %CDP_TEMP_PRIOR_DROP_FOLDER_CONTAINER_PATH%\current\drop
+mkdir "%DIR%%SIGNING_DIR%\oms-signing"
 
-mkdir %DIR%\%SIGNING_DIR%
+Xcopy /Y %DIR%drop\Build_x64\outputs\build\buildoutput\Linux_ULINUX_1.0_x64_64_Release\*.sha256sums %DIR%\%SIGNING_DIR%\oms-signing
 
-mkdir "%DIR%\%SIGNING_DIR%\oms-signing"
+dir %DIR%%SIGNING_DIR%\oms-signing
 
-Xcopy /Y %CDP_TEMP_PRIOR_DROP_FOLDER_CONTAINER_PATH%\current\drop\Build_x64\outputs\build\buildoutput\Linux_ULINUX_1.0_x64_64_Release\*.sha256sums %DIR%\%SIGNING_DIR%\oms-signing
-
-dir %DIR%\%SIGNING_DIR%\oms-signing
-
-cd %DIR%\%SIGNING_DIR%\oms-signing
+cd %DIR%%SIGNING_DIR%\oms-signing
 
 ren *.sha256sums *.asc
 


### PR DESCRIPTION
Following guidance [here](https://onebranch.visualstudio.com/Pipeline/_wiki/wikis/Pipeline.wiki/2829/Work-around-Signing-Large-Artifacts-Produced-in-Linux-Phase). 
Successful build with these new settings [here](https://github-private.visualstudio.com/microsoft/_build/results?buildId=3636&view=results).